### PR TITLE
doc: Improve instructions for viewing local db in Adminer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ To start the database container, run the following command:
 npm run db:start
 ```
 
-Then visit [localhost](http://localhost:8080) to view the db. The username and password are both `mysql`.
+Then visit [localhost](http://localhost:8080) to view the db.
+
+To log in, set the following fields and press "Login":
+- System: `MySQL`
+- Server: `db`
+- Username: `root`
+- Password: `mysql`
+- Database: `mysql`
 
 ## Learn More
 


### PR DESCRIPTION
- README now lists two more fields necessary to log in (_Server_ and _Database_)
- Clarified the username field in Adminer is _root_ rather than _mysql_